### PR TITLE
Add GitHub Actions deployment pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,103 @@
+name: Build and Deploy Bribery
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+env:
+  DOTNET_VERSION: '8.0.x'
+  NODE_VERSION: '18.x'
+  REMOTE_API_PATH: '/var/www/bribery-api'
+  REMOTE_WEB_PATH: '/var/www/bribery-client'
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Restore .NET dependencies
+        run: dotnet restore
+
+      - name: Run backend tests
+        run: dotnet test --configuration Release
+
+      - name: Publish backend API
+        run: dotnet publish src/Bribery.Api/Bribery.Api.csproj -c Release -o deployment/api
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+          cache-dependency-path: frontend/bribery-client/package-lock.json
+
+      - name: Install frontend dependencies
+        working-directory: frontend/bribery-client
+        run: npm ci
+
+      - name: Run frontend tests
+        working-directory: frontend/bribery-client
+        run: npm test -- --watch=false --browsers=ChromeHeadlessNoSandbox
+
+      - name: Build frontend for production
+        working-directory: frontend/bribery-client
+        run: npm run build -- --configuration production
+
+      - name: Prepare deployment bundle
+        run: |
+          mkdir -p deployment/frontend
+          cp -r frontend/bribery-client/dist/bribery-client/browser/. deployment/frontend/
+          tar -czf bribery-deploy.tar.gz -C deployment .
+
+      - name: Upload bundle to server
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.DEPLOY_HOST }}
+          username: ${{ secrets.DEPLOY_USER }}
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          passphrase: ${{ secrets.DEPLOY_SSH_PASSPHRASE }}
+          port: ${{ secrets.DEPLOY_PORT || '22' }}
+          source: "bribery-deploy.tar.gz"
+          target: "/tmp"
+
+      - name: Deploy on remote host
+        uses: appleboy/ssh-action@v1.0.0
+        with:
+          host: ${{ secrets.DEPLOY_HOST }}
+          username: ${{ secrets.DEPLOY_USER }}
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          passphrase: ${{ secrets.DEPLOY_SSH_PASSPHRASE }}
+          port: ${{ secrets.DEPLOY_PORT || '22' }}
+          script: |
+            set -euo
+            mkdir -p /tmp/bribery-deployment
+            tar -xzf /tmp/bribery-deploy.tar.gz -C /tmp/bribery-deployment
+            sudo mkdir -p "${{ env.REMOTE_API_PATH }}"
+            sudo rsync -a --delete /tmp/bribery-deployment/api/ "${{ env.REMOTE_API_PATH }}/"
+            sudo mkdir -p "${{ env.REMOTE_WEB_PATH }}"
+            sudo rsync -a --delete /tmp/bribery-deployment/frontend/ "${{ env.REMOTE_WEB_PATH }}/"
+            if id -u www-data >/dev/null 2>&1; then
+              sudo chown -R www-data:www-data "${{ env.REMOTE_WEB_PATH }}"
+            fi
+            if sudo systemctl list-unit-files | grep -q '^bribery-api.service'; then
+              sudo systemctl restart bribery-api
+            else
+              echo 'bribery-api.service not found - skipping restart'
+            fi
+            if sudo systemctl list-unit-files | grep -q '^nginx.service'; then
+              sudo systemctl reload nginx
+            else
+              echo 'nginx.service not found - skipping reload'
+            fi
+            rm -f /tmp/bribery-deploy.tar.gz
+            rm -rf /tmp/bribery-deployment

--- a/docs/ORACLE_FREE_TIER_HOSTING.md
+++ b/docs/ORACLE_FREE_TIER_HOSTING.md
@@ -1,11 +1,12 @@
 # Hosting Bribery on an Oracle Cloud Free Tier Compute Instance
 
-The following steps describe how to provision an Oracle Cloud Infrastructure (OCI) Free Tier VM, deploy the Bribery backend (ASP.NET Core API) and frontend (Angular), and expose the application securely to the internet.
+The following guide walks through provisioning an Oracle Cloud Infrastructure (OCI) Free Tier VM, preparing it to run the Bribery backend (ASP.NET Core API) and frontend (Angular), and wiring up the automated deployment pipeline that lives in `.github/workflows/deploy.yml`.
 
 > **Assumptions**
 > - You already have an Oracle Cloud account with Free Tier access.
 > - A public DNS record is optional; you can operate with the public IP assigned to the instance.
 > - Commands target the Oracle-provided Ubuntu 22.04 image. Adjust package commands accordingly if you choose a different OS.
+> - You have push access to the GitHub repository and permission to manage Actions secrets.
 
 ## 1. Provision the compute instance
 
@@ -15,7 +16,7 @@ The following steps describe how to provision an Oracle Cloud Infrastructure (OC
 4. Under **Image and shape**, choose the latest Ubuntu 22.04 image and the `VM.Standard.A1.Flex` shape (1 OCPU, 6GB RAM is typically available).
 5. Leave the boot volume at the default size (typically 46GB) or adjust as needed.
 6. Under **Networking**, either select an existing VCN/Subnet or allow OCI to create a new one. Ensure the subnet is public and assigned a public IPv4 address.
-7. Upload or generate an SSH key pair. Keep the private key secure—you will use it to connect to the instance.
+7. Upload or generate an SSH key pair. Keep the private key secure—you will use it to connect to the instance and from GitHub Actions.
 8. Click **Create** and wait for the instance to reach the `RUNNING` state.
 
 ## 2. Configure network access
@@ -23,7 +24,7 @@ The following steps describe how to provision an Oracle Cloud Infrastructure (OC
 1. From the instance details page, note the **Public IPv4 address**.
 2. Open the **Subnet** linked to the instance and edit the **Security List**:
    - Add ingress rules allowing TCP traffic on ports `22` (SSH), `80` (HTTP), and `443` (HTTPS) from your desired CIDR ranges (for public access use `0.0.0.0/0`).
-   - Add egress rule permitting outbound traffic to `0.0.0.0/0` so the server can download dependencies.
+   - Add an egress rule permitting outbound traffic to `0.0.0.0/0` so the server can download dependencies.
 3. If you are using a network security group (NSG), mirror the same rules there.
 
 ## 3. Connect to the instance
@@ -38,11 +39,11 @@ The default user for Ubuntu images is `ubuntu`.
 
 ## 4. Install runtime dependencies
 
-Update the package index and install prerequisites:
+Update the package index and install prerequisites (the deployment workflow relies on `rsync` to sync files onto the server):
 
 ```bash
 sudo apt-get update
-sudo apt-get install -y apt-transport-https ca-certificates curl git gnupg nginx
+sudo apt-get install -y apt-transport-https ca-certificates curl git gnupg nginx rsync
 ```
 
 ### Install .NET 8 SDK
@@ -65,28 +66,18 @@ sudo npm install -g @angular/cli
 
 (Headless Chrome dependencies for the Angular tests are optional in production. They are already bundled with Puppeteer for local development.)
 
-## 5. Deploy the application
+## 5. Configure system services (one-time server work)
 
-1. Clone the repository and build the artifacts:
-   ```bash
-   git clone https://github.com/<your-org>/briberyv2.git
-   cd briberyv2
-   dotnet restore
-   npm --prefix frontend/bribery-client install
-   npm --prefix frontend/bribery-client run build -- --configuration production
-   ```
-   The Angular build outputs static files to `frontend/bribery-client/dist/bribery-client/browser`.
-
-2. Publish the backend API to a self-contained folder:
-   ```bash
-   dotnet publish src/Bribery.Api/Bribery.Api.csproj -c Release -o /var/www/bribery-api
-   ```
-
-## 6. Configure system services
+The GitHub Actions workflow will publish the API into `/var/www/bribery-api` and the Angular static assets into `/var/www/bribery-client`. Prepare those locations and the reverse proxy before enabling automated deployments.
 
 ### Backend API service
 
-1. Create a systemd unit at `/etc/systemd/system/bribery-api.service`:
+1. Create the target directories (the workflow also creates them but doing so now allows the service file to reference a stable path):
+   ```bash
+   sudo mkdir -p /var/www/bribery-api
+   sudo mkdir -p /var/www/bribery-client
+   ```
+2. Create a systemd unit at `/etc/systemd/system/bribery-api.service`:
    ```ini
    [Unit]
    Description=Bribery ASP.NET Core API
@@ -104,11 +95,10 @@ sudo npm install -g @angular/cli
    [Install]
    WantedBy=multi-user.target
    ```
-2. Reload systemd and start the service:
+3. Reload systemd so it recognises the new service and enable it for future boots (it will be started automatically by the deployment workflow once the binaries are in place):
    ```bash
    sudo systemctl daemon-reload
-   sudo systemctl enable --now bribery-api
-   sudo systemctl status bribery-api
+   sudo systemctl enable bribery-api
    ```
 
 ### Nginx reverse proxy & static hosting
@@ -141,35 +131,43 @@ sudo npm install -g @angular/cli
        }
    }
    ```
-3. Copy the Angular build into `/var/www/bribery-client`:
-   ```bash
-   sudo mkdir -p /var/www/bribery-client
-   sudo cp -r frontend/bribery-client/dist/bribery-client/browser/* /var/www/bribery-client/
-   sudo chown -R www-data:www-data /var/www/bribery-client
-   ```
-4. Enable the Nginx site and reload:
+3. Enable the site and reload Nginx:
    ```bash
    sudo ln -s /etc/nginx/sites-available/bribery /etc/nginx/sites-enabled/bribery
    sudo nginx -t
-   sudo systemctl restart nginx
+   sudo systemctl reload nginx
    ```
 
 (Optional) Configure HTTPS with [Let’s Encrypt](https://certbot.eff.org/instructions?ws=nginx&os=ubuntufocal) once your DNS record resolves to the instance.
 
-## 7. Verify the deployment
+## 6. Configure the GitHub Actions deployment
+
+The repository includes a GitHub Actions workflow at `.github/workflows/deploy.yml`. It restores dependencies, runs the .NET and Angular test suites, builds release artifacts, securely copies them to the server using `scp`, and then promotes them into `/var/www/bribery-api` and `/var/www/bribery-client` over SSH.
+
+Perform the following manual steps so the workflow can reach your Oracle VM:
+
+1. In the GitHub UI, navigate to **Settings → Secrets and variables → Actions** and create the following repository secrets:
+   - `DEPLOY_HOST` – the public IP address or DNS name of your OCI instance.
+   - `DEPLOY_USER` – the SSH user (e.g., `ubuntu`). This user must be able to run `sudo` for `rsync`, `chown`, and `systemctl` without an interactive password prompt.
+   - `DEPLOY_SSH_KEY` – the private key that matches the public key uploaded when provisioning the instance. Paste it in PEM format.
+   - `DEPLOY_SSH_PASSPHRASE` – *(optional)* passphrase for the private key above.
+   - `DEPLOY_PORT` – *(optional)* SSH port if you do not use the default `22`.
+2. Ensure the instance allows SSH connections from the GitHub Actions runners (they originate from GitHub’s published IP ranges). If necessary, widen your security list to `0.0.0.0/0` for port `22`.
+3. If you need to use different deployment directories or a different service name, edit the environment variables at the top of `.github/workflows/deploy.yml` before committing. By default it targets `/var/www/bribery-api`, `/var/www/bribery-client`, restarts the `bribery-api` systemd unit, and reloads `nginx` after each deployment.
+
+## 7. Trigger the deployment pipeline
+
+1. Push to the `main` branch (or merge a pull request into `main`). This automatically runs the **Build and Deploy Bribery** workflow.
+2. To deploy on demand without a new commit, go to **Actions → Build and Deploy Bribery → Run workflow** and select the branch you want to deploy.
+3. Monitor the workflow logs to confirm that the build, tests, artifact upload, and remote deployment all succeed. Any SSH or service configuration issues will surface here.
+
+## 8. Verify the deployment
 
 1. Visit `http://<public-ip>/` (or your domain) in a browser. You should see the Bribery landing page.
 2. Create a lobby and ensure API calls succeed. If requests fail, check:
-   - `sudo journalctl -u bribery-api -f` for backend logs.
+   - The GitHub Actions workflow logs for deployment errors.
+   - `sudo journalctl -u bribery-api -f` for backend logs on the instance.
    - `sudo tail -f /var/log/nginx/error.log` for proxy issues.
-3. To update to a newer release, pull changes, rebuild the Angular app, republish the API, and restart the services:
-   ```bash
-   cd ~/briberyv2
-   git pull
-   npm --prefix frontend/bribery-client run build -- --configuration production
-   sudo cp -r frontend/bribery-client/dist/bribery-client/browser/* /var/www/bribery-client/
-   dotnet publish src/Bribery.Api/Bribery.Api.csproj -c Release -o /var/www/bribery-api
-   sudo systemctl restart bribery-api nginx
-   ```
+3. To roll out future changes, simply merge to `main` or manually dispatch the workflow. It will redeploy the latest code, run the tests, and recycle the services automatically.
 
-The Bribery game is now available to your players via the Oracle Cloud Free Tier instance.
+The Bribery game is now available to your players via the Oracle Cloud Free Tier instance with continuous delivery powered by GitHub Actions.


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that builds, tests, and deploys the API and Angular client to the Oracle VM
- refresh the Oracle Free Tier hosting guide to document the automated deployment and required manual secrets configuration

## Testing
- not run (docs and workflow only)


------
https://chatgpt.com/codex/tasks/task_e_68d048ac07a8833092bfbe49f25836c2